### PR TITLE
Fix username length

### DIFF
--- a/check_process
+++ b/check_process
@@ -12,7 +12,7 @@
         setup_private=1
         setup_public=1
         upgrade=1
-        upgrade=1   from_commit=6b47f5e5d81ac3239709d581b25a2fa331226843
+        upgrade=1   from_commit=83500d6e866539d56a0aed6f288a8a8ce02a674b
         backup_restore=1
         multi_instance=1
         port_already_use=0
@@ -21,7 +21,7 @@
 Email=
 Notification=none
 ;;; Upgrade options
-    ; commit=6b47f5e5d81ac3239709d581b25a2fa331226843
+    ; commit=83500d6e866539d56a0aed6f288a8a8ce02a674b
         name=Name and date of the commit.
         manifest_arg=domain=DOMAIN&path=PATH&admin=USER&is_public=1&
 

--- a/conf/common.php
+++ b/conf/common.php
@@ -2,10 +2,15 @@
 
 return [
     'components' => [
-		'db' => [
+        'db' => [
             'dsn' => 'mysql:host=localhost;dbname=__DB_NAME__',
             'username' => '__DB_USER__',
             'password' => '__DB_PWD__',
         ],
+    ],
+    'modules' => [
+        'user' => [
+            'minimumUsernameLength' => 1
+        ]
     ]
 ];

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         "name": "Nils Van Zuijlen",
         "url": "https://github.com/nils-van-zuijlen"
     },
-    "version": "1.8.2~ynh1",
+    "version": "1.8.2~ynh2",
     "requirements": {
         "yunohost": ">= 4.1.7"
     },


### PR DESCRIPTION
## Problem

- YunoHost allows usernames to be as short as 1 character while, by default, HumHub requires them to be 4 characters long.

## Solution

- Configure HumHub to allow for the shortest usernames

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
