### PR TITLE
Better way to get user info / drop reliance on ynh_get_plain_key

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -137,9 +137,9 @@ ynh_systemd_action --service_name=nginx --action=reload
 ynh_script_progression --message="Finalizing installation..." --weight=2
 
 admin_temp_pass=$(ynh_string_random 6)
-admin_email=$(yunohost user info "$admin" --output-as plain | ynh_get_plain_key mail)
-admin_firstname=$(yunohost user info "$admin" --output-as plain | ynh_get_plain_key firstname)
-admin_lastname=$(yunohost user info "$admin" --output-as plain | ynh_get_plain_key lastname)
+admin_email=$(ynh_user_get_info "$admin" mail)
+admin_firstname=$(ynh_user_get_info "$admin" firstname)
+admin_lastname=$(ynh_user_get_info "$admin" lastname)
 
 ynh_local_curl "/index.php?r=installer/index/go"
 


### PR DESCRIPTION
## Problem

- This app is the last one to use deprecated helper ynh_get_plain_key

## Solution

- Use `ynh_user_get_info`, simpler way to get info for a user

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
