### PR TITLE
Add write access to user $app on uploads folder

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -210,7 +210,7 @@ chown -R $app $final_path/assets
 chown -R $app $final_path/protected/config
 chown -R $app $final_path/protected/modules
 chown -R $app $final_path/protected/runtime
-chown -R $app $final_path/uploads/*
+chown -R $app $final_path/uploads
 
 #=================================================
 # SETUP CRON CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -163,7 +163,7 @@ chown -R $app $final_path/assets
 chown -R $app $final_path/protected/config
 chown -R $app $final_path/protected/modules
 chown -R $app $final_path/protected/runtime
-chown -R $app $final_path/uploads/*
+chown -R $app $final_path/uploads
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

- Can't upload custom logo and icon
- https://github.com/YunoHost-Apps/humhub_ynh/issues/24
- In administration panel -> information -> prerequisites, we can see: ![image](https://user-images.githubusercontent.com/8107411/166930023-e50cbadc-6e81-4ffc-aa0f-b3bf3d73b793.png)


## Solution

- Add write access right to user $app on uploads folder.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
