### PR TITLE
Update auth-basic module version

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,7 +11,7 @@ php_dependencies="php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-curl php${
 # dependencies used by the app (must be on a single line)
 pkg_dependencies="$php_dependencies"
 
-HUMHUB_AUTH_BASIC_VERSION=0.1.0
+HUMHUB_AUTH_BASIC_VERSION=0.1.2
 HUMHUB_AUTH_BASIC_PATH="/protected/modules/auth-basic"
 
 #=================================================


### PR DESCRIPTION
## Problem

- Use of old version of auth-basic module

## Solution

- Install new version of auth-basic module that fix use of impersonate feature

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
