### PR TITLE
Use module auth-basic 0.2.0

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-HUMHUB_AUTH_BASIC_VERSION=0.1.1
+HUMHUB_AUTH_BASIC_VERSION=0.2.0
 HUMHUB_AUTH_BASIC_PATH="/protected/modules/auth-basic"
 
 #=================================================


### PR DESCRIPTION
## Problem

- Version 0.1.x of auth basic module doesn't work with humhub 1.14.x

## Solution

- Use version 0.2.0 of auth basic module

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
