### PR TITLE
Enable pretty URLs

### DIFF
--- a/conf/common.php
+++ b/conf/common.php
@@ -9,8 +9,12 @@ return [
         ],
     ],
     'modules' => [
+        'urlManager' => [
+            'showScriptName' => false,
+            'enablePrettyUrl' => true,
+        ],
         'user' => [
-            'minimumUsernameLength' => 1
-        ]
+            'minimumUsernameLength' => 1,
+        ],
     ]
 ];


### PR DESCRIPTION
## Problem

By default, the HumHub URL includes a index.php file part and looks like https://example.com/index.php?r=dashboard%2Fdashboard. Using the Pretty URL or URL Rewriting feature, shorter and more meaningful URLs can be created such as https://example.com/dashboard.

See https://docs.humhub.org/docs/admin/installation/#pretty-urls

## Solution

Enable pretty URLs in config.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
